### PR TITLE
Update fragment shaders to compile on AMD Cards

### DIFF
--- a/Shaders/Voxel Cone Tracing/voxel_cone_tracing.frag
+++ b/Shaders/Voxel Cone Tracing/voxel_cone_tracing.frag
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------------------------//
 // A voxel cone tracing implementation for real-time global illumination,                       //
 // refraction, specular, glossy and diffuse reflections, and soft shadows.                      //
 // The implementation traces cones through a 3D texture which contains a                        //
@@ -80,8 +80,8 @@ in vec3 normalFrag;
 
 out vec4 color;
 
-const vec3 normal = normalize(normalFrag); 
-const float MAX_DISTANCE = distance(vec3(abs(worldPositionFrag)), vec3(-1));
+vec3 normal = normalize(normalFrag); 
+float MAX_DISTANCE = distance(vec3(abs(worldPositionFrag)), vec3(-1));
 
 // Returns an attenuation factor given a distance.
 float attenuate(float dist){ dist *= DIST_FACTOR; return 1.0f / (CONSTANT + LINEAR * dist + QUADRATIC * dist * dist); }
@@ -97,7 +97,7 @@ vec3 orthogonal(vec3 u){
 vec3 scaleAndBias(const vec3 p) { return 0.5f * p + vec3(0.5f); }
 
 // Returns true if the point p is inside the unity cube. 
-bool isInsideCube(const vec3 p, float e = 0) { return abs(p.x) < 1 + e && abs(p.y) < 1 + e && abs(p.z) < 1 + e; }
+bool isInsideCube(const vec3 p, float e) { return abs(p.x) < 1 + e && abs(p.y) < 1 + e && abs(p.z) < 1 + e; }
 
 // Returns a soft shadow blend by using shadow cone tracing.
 // Uses 2 samples per step, so it's pretty expensive.
@@ -112,7 +112,7 @@ float traceShadowCone(vec3 from, vec3 direction, float targetDistance){
 
 	while(dist < STOP && acc < 1){	
 		vec3 c = from + dist * direction;
-		if(!isInsideCube(c)) break;
+		if(!isInsideCube(c, 0)) break;
 		c = scaleAndBias(c);
 		float l = pow(dist, 2); // Experimenting with inverse square falloff for shadows.
 		float s1 = 0.062 * textureLod(texture3D, c, 1 + 0.75 * l).a;
@@ -166,7 +166,7 @@ vec3 traceSpecularVoxelCone(vec3 from, vec3 direction){
 	// Trace.
 	while(dist < MAX_DISTANCE && acc.a < 1){ 
 		vec3 c = from + dist * direction;
-		if(!isInsideCube(c)) break;
+		if(!isInsideCube(c, 0)) break;
 		c = scaleAndBias(c); 
 		
 		float level = 0.1 * material.specularDiffusion * log2(1 + dist / VOXEL_SIZE);

--- a/Shaders/Voxelization/Visualization/voxel_visualization.frag
+++ b/Shaders/Voxelization/Visualization/voxel_visualization.frag
@@ -19,13 +19,13 @@ out vec4 color;
 vec3 scaleAndBias(vec3 p) { return 0.5f * p + vec3(0.5f); }
 
 // Returns true if p is inside the unity cube (+ e) centered on (0, 0, 0).
-bool isInsideCube(vec3 p, float e = 0.2f) { return abs(p.x) < 1 + e && abs(p.y) < 1 + e && abs(p.z) < 1 + e; }
+bool isInsideCube(vec3 p, float e) { return abs(p.x) < 1 + e && abs(p.y) < 1 + e && abs(p.z) < 1 + e; }
 
 void main() {
 	const float mipmapLevel = state;
 
 	// Initialize ray.
-	const vec3 origin = isInsideCube(cameraPosition) ? 
+	const vec3 origin = isInsideCube(cameraPosition, 0.2f) ? 
 		cameraPosition : texture(textureFront, textureCoordinateFrag).xyz;
 	vec3 direction = texture(textureBack, textureCoordinateFrag).xyz - origin;
 	const uint numberOfSteps = uint(INV_STEP_LENGTH * length(direction));

--- a/Shaders/Voxelization/voxelization.frag
+++ b/Shaders/Voxelization/voxelization.frag
@@ -49,11 +49,11 @@ vec3 calculatePointLight(const PointLight light){
 
 vec3 scaleAndBias(vec3 p) { return 0.5f * p + vec3(0.5f); }
 
-bool isInsideCube(const vec3 p, float e = 0) { return abs(p.x) < 1 + e && abs(p.y) < 1 + e && abs(p.z) < 1 + e; }
+bool isInsideCube(const vec3 p, float e) { return abs(p.x) < 1 + e && abs(p.y) < 1 + e && abs(p.z) < 1 + e; }
 
 void main(){
 	vec3 color = vec3(0.0f);
-	if(!isInsideCube(worldPositionFrag)) return;
+	if(!isInsideCube(worldPositionFrag, 0)) return;
 
 	// Calculate diffuse lighting fragment contribution.
 	const uint maxLights = min(numberOfLights, MAX_LIGHTS);

--- a/Source/Graphic/Graphics.cpp
+++ b/Source/Graphic/Graphics.cpp
@@ -140,7 +140,7 @@ void Graphics::initVoxelization()
 {
 	voxelizationMaterial = MaterialStore::getInstance().findMaterialWithName("voxelization");
 
-	assert(voxelMaterial != nullptr);
+	assert(voxelizationMaterial != nullptr);
 
 	const std::vector<GLfloat> texture3D(4 * voxelTextureSize * voxelTextureSize * voxelTextureSize, 0.0f);
 	voxelTexture = new Texture3D(texture3D, voxelTextureSize, voxelTextureSize, voxelTextureSize, true);

--- a/voxel-cone-tracing.vcxproj
+++ b/voxel-cone-tracing.vcxproj
@@ -106,7 +106,8 @@
       <AdditionalOptions>/NODEFAULTLIB:libcmt.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(TargetDir)$(ProjectName).dll" "$(SolutionDir)lib\$(ProjectName).dll"</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/voxel-cone-tracing.vcxproj
+++ b/voxel-cone-tracing.vcxproj
@@ -106,8 +106,7 @@
       <AdditionalOptions>/NODEFAULTLIB:libcmt.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>
-      </Command>
+        <Command>copy /Y "$(TargetDir)$(ProjectName).dll" "$(SolutionDir)lib\$(ProjectName).dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
Was having issues compiling the fragment shaders on my AMD card, removal of default function parameters and const qualifiers resolved those issues.

Also removed post build step that does not appear to belong.

Updated assert with what appeared to be an incorrect reference.

Thanks, This is very cool!